### PR TITLE
Add Bulb color conversion test

### DIFF
--- a/tests/test_bulb_color.py
+++ b/tests/test_bulb_color.py
@@ -1,0 +1,21 @@
+from custom_components.sengledapi.sengledapi.devices.bulbs.bulb import Bulb
+
+
+def test_convert_color_ha():
+    bulb = Bulb(
+        api=None,
+        device_mac="00:11:22:33:44:55",
+        friendly_name="Test",
+        state=False,
+        device_model="model",
+        isonline=True,
+        support_color=True,
+        support_color_temp=True,
+        support_brightness=True,
+        jsession_id="",
+        country="us",
+        wifi=False,
+    )
+    result = bulb.convert_color_HA((255, 128, 0))
+    assert result == "255:128:0"
+


### PR DESCRIPTION
## Summary
- add pytest to ensure Bulb convert_color_HA outputs a colon-separated string

## Testing
- `pytest -q` *(fails: command not found)*