### PR TITLE
Fix 'available' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find [Supported Products](https://github.com/jfarmer08/ha-sengledapi/wik
 * This is an unofficial implementation of the api and therefore may be disabled or broken at anytime by Sengled
 * I only have Element Classic A19 Kit (Light bulbs + Hub) https://us.sengled.com/products/element-classic-kit and the Wifi LED Multicolor A19 Bulb https://us.sengled.com/products/sengled-smart-wi-fi-led-multicolor-a19-bulb to test.
 
-* An update from Sengled may break this integration without my knowledge. **Please use the betas as they become avaliable**
+* An update from Sengled may break this integration without my knowledge. **Please use the betas as they become available**
 
 ** Wifi bulbs are supported by adding ```wifi: true``` to your configuration. All functions should be supported.
 

--- a/custom_components/sengledapi/sengledapi/devices/bulbs/bulb.py
+++ b/custom_components/sengledapi/sengledapi/devices/bulbs/bulb.py
@@ -288,7 +288,7 @@ class Bulb:
                     if items.uuid == self._device_mac:
                         self._friendly_name = items.name
                         self._state = items.switch
-                        self._avaliable = items.isOnline
+                        self._available = items.isOnline
                         self._device_rssi = items.device_rssi
                         # Supported Features
                         if self._support_brightness:
@@ -326,7 +326,7 @@ class Bulb:
                             if items.uuid == self._device_mac:
                                 self._friendly_name = items.name
                                 self._state = items.switch
-                                self._avaliable = items.isOnline
+                                self._available = items.isOnline
                                 self._device_rssi = round(
                                     self.translate(
                                         int(items.device_rssi), 0, 5, -100, -30

--- a/custom_components/sengledapi/sengledapi/devices/switch.py
+++ b/custom_components/sengledapi/sengledapi/devices/switch.py
@@ -23,7 +23,7 @@ class Switch:
         self._device_mac = device_mac
         self._friendly_name = friendly_name
         self._state = state
-        self._avaliable = True
+        self._available = True
         self._just_changed_state = False
         self._device_model = device_model
         self._accesstoken = accesstoken
@@ -84,6 +84,6 @@ class Switch:
                     self._state = (
                         True if int(items["attributes"]["onoff"]) == 1 else False
                     )
-                    self._avaliable = (
+                    self._available = (
                         False if int(items["attributes"]["isOnline"]) == 0 else True
                     )

--- a/custom_components/sengledapi/switch.py
+++ b/custom_components/sengledapi/switch.py
@@ -35,7 +35,7 @@ class SengledSwitch(SwitchDevice):
         self._switch = switch
         self._name = switch._friendly_name
         self._state = switch._state
-        self._avaliable = True
+        self._available = True
         self._device_mac = switch._device_mac
         self._device_model = switch._device_model
 
@@ -47,7 +47,7 @@ class SengledSwitch(SwitchDevice):
     @property
     def available(self):
         """Return the connection status of this switch"""
-        return self._avaliable
+        return self._available
 
     @property
     def is_on(self):
@@ -64,7 +64,7 @@ class SengledSwitch(SwitchDevice):
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "state": self._state,
-            "available": self._avaliable,
+            "available": self._available,
             "device model": self._device_model,
             "mac": self._device_mac,
         }

--- a/info.md
+++ b/info.md
@@ -19,7 +19,7 @@ You can find [Supported Products](https://github.com/jfarmer08/ha-sengledapi/wik
 * This is an unofficial implementation of the api and therefore may be disabled or broken at anytime by Sengled
 * I only have Element Classic A19 Kit (Light bulbs + Hub) https://us.sengled.com/products/element-classic-kit and the Wifi LED Multicolor A19 Bulb https://us.sengled.com/products/sengled-smart-wi-fi-led-multicolor-a19-bulb to test.
 
-* An update from Sengled may break this integration without my knowledge. **Please use the betas as they become avaliable**
+* An update from Sengled may break this integration without my knowledge. **Please use the betas as they become available**
 
 ** Wifi bulbs are supported by adding ```wifi: true``` to your configuration. All functions should be supported.
 


### PR DESCRIPTION
## Summary
- rename `_avaliable` fields to `_available` across switch and bulb helpers
- update documentation with correct spelling

## Testing
- `python -m py_compile custom_components/sengledapi/switch.py custom_components/sengledapi/sengledapi/devices/bulbs/bulb.py custom_components/sengledapi/sengledapi/devices/switch.py`
- `python -m py_compile custom_components/sengledapi/light.py`
